### PR TITLE
Add API description test for SurveySerializer

### DIFF
--- a/api-description/forms/pk/get.json
+++ b/api-description/forms/pk/get.json
@@ -30,8 +30,8 @@
                     "fields": [
                         {
                             "id": 2,
-                            "name": "What is answer to the ultimate question of life, the universe, and everything?",
-                            "help_text": null,
+                            "name": "What is the answer to the ultimate question?",
+                            "help_text": "",
                             "field_type": "number",
                             "required": false,
                             "answers": []
@@ -39,7 +39,7 @@
                         {
                             "id": 3,
                             "name": "How much percentage does it take?",
-                            "help_text": null,
+                            "help_text": "",
                             "field_type": "percentage",
                             "required": true,
                             "answers": []
@@ -62,7 +62,7 @@
                         {
                             "id": 5,
                             "name": "Choose more than one answer.",
-                            "help_text": null,
+                            "help_text": "",
                             "field_type": "checkbox",
                             "required": false,
                             "answers": ["One time", "Two times", "Three times or more"]

--- a/surveys/serializers.py
+++ b/surveys/serializers.py
@@ -22,10 +22,11 @@ class SurveyFieldsetSerializer(serializers.ModelSerializer):
 class SurveySerializer(serializers.ModelSerializer):
     """Serializer for a full survey."""
     fieldsets = SurveyFieldsetSerializer(many=True)
+    url = serializers.CharField(source='get_api_url')
 
     class Meta:
         model = models.Survey
-        fields = ['name', 'description', 'fieldsets']
+        fields = ['name', 'description', 'url', 'fieldsets']
 
 
 class UserResponseSerializer(serializers.ModelSerializer):

--- a/surveys/serializers.py
+++ b/surveys/serializers.py
@@ -19,14 +19,16 @@ class SurveyFieldsetSerializer(serializers.ModelSerializer):
         fields = ['id', 'name', 'description', 'fields']
 
 
-class SurveySerializer(serializers.ModelSerializer):
+class SurveySerializer(serializers.HyperlinkedModelSerializer):
     """Serializer for a full survey."""
     fieldsets = SurveyFieldsetSerializer(many=True)
-    url = serializers.CharField(source='get_api_url')
 
     class Meta:
         model = models.Survey
         fields = ['name', 'description', 'url', 'fieldsets']
+        extra_kwargs = {
+            'url': {'view_name': 'survey-form'},
+        }
 
 
 class UserResponseSerializer(serializers.ModelSerializer):

--- a/surveys/tests/test_serializers.py
+++ b/surveys/tests/test_serializers.py
@@ -42,6 +42,7 @@ class TestSerializers(TestCase):
         expected_data = {
             'name': self.survey.name,
             'description': self.survey.description,
+            'url': self.survey.get_api_url(),
             'fieldsets': [fieldset_data]
         }
 

--- a/surveys/tests/test_views_api.py
+++ b/surveys/tests/test_views_api.py
@@ -20,5 +20,7 @@ class TestSurveyView(RequestTestCase):
         # that it's the same data here and hasn't been tampered with.  That way, if the
         # serializer is broken, only that test should fail, and this test will be
         # unconcerned by changes to the serializer format.
-        expected_data = SurveySerializer(instance=self.survey).data
+        expected_data = SurveySerializer(
+            instance=self.survey, context={'request': request}
+        ).data
         self.assertEqual(response.data, expected_data)

--- a/surveys/tests/test_views_api.py
+++ b/surveys/tests/test_views_api.py
@@ -21,6 +21,7 @@ class TestSurveyView(RequestTestCase):
         # serializer is broken, only that test should fail, and this test will be
         # unconcerned by changes to the serializer format.
         expected_data = SurveySerializer(
-            instance=self.survey, context={'request': request}
+            instance=self.survey,
+            context={'request': request},
         ).data
         self.assertEqual(response.data, expected_data)

--- a/surveys/tests/utils.py
+++ b/surveys/tests/utils.py
@@ -1,9 +1,14 @@
+from incuna_test_utils.testcases.api_request import BaseAPIRequestTestCase
 from incuna_test_utils.testcases.request import BaseRequestTestCase
 
 from . import factories
 
 
 class RequestTestCase(BaseRequestTestCase):
+    user_factory = factories.UserFactory
+
+
+class APIRequestTestCase(BaseAPIRequestTestCase):
     user_factory = factories.UserFactory
 
 


### PR DESCRIPTION
The huge pile of setup is kind of awful and the error output is totally useless, but it works.  I think.  I tried several ways to produce decent error output and each one failed, but suggestions are welcome :P

@incuna/backend @wytrych review please?

FYI @wytrych I made some minor changes to the JSON.  `help_text` is now `''` when empty rather than `null`, since the serializer gives `''`.  I also selfishly shortened one of the questions so I didn't have to break it over multiple lines in the test setup code.