### PR TITLE
Rename `admin.py` to `base_admin.py`

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,39 @@ Allows the creation of custom questionnaires and surveys via the admin.
 
 To set the `apiRoot` use `ProjectConfigProvider.setApiRoot()`
 
+## Backend
+
+### Admin
+
+Create an `admin.py` with the following content:
+
+```python
+from django.contrib import admin
+from surveys.base_admin import (
+    SurveyAdmin,
+    SurveyFieldAdmin,
+    SurveyFieldOrderingAdmin,
+    SurveyFieldsetAdmin,
+    SurveyFieldsetOrderingAdmin,
+    UserResponseAdmin,
+)
+from surveys.models import (
+    Survey,
+    SurveyField,
+    SurveyFieldOrdering,
+    SurveyFieldset,
+    SurveyFieldsetOrdering,
+    UserResponse,
+)
+
+admin.site.register(models.SurveyField, SurveyFieldAdmin)
+admin.site.register(models.SurveyFieldset, SurveyFieldsetAdmin)
+admin.site.register(models.Survey, SurveyAdmin)
+admin.site.register(models.SurveyFieldOrdering, SurveyFieldOrderingAdmin)
+admin.site.register(models.SurveyFieldsetOrdering, SurveyFieldsetOrderingAdmin)
+admin.site.register(models.UserResponse, UserResponseAdmin)
+```
+
 # Development
 
 ## Frontend

--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,9 @@
 
 This project uses Semantic Versioning (2.0).
 
+### 0.2.0 (upcoming)
+* Rename `admin.py` to `base_admin.py`.
+
 ### 0.1.1
 * Fix potential frontend bug using fiedset index rather than id.
 * Simplify internal frontend model representation to match api survey response get.

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,7 +12,7 @@ ignore = D100,D101,D102,D104,D203,D204
 
 [coverage:run]
 source = surveys
-omit = *migrations*,*tests*,wsgi.py
+omit = surveys/base_admin.py,*migrations*,*tests*,wsgi.py
 
 [coverage:report]
 show_missing = True

--- a/surveys/base_admin.py
+++ b/surveys/base_admin.py
@@ -44,11 +44,3 @@ class SurveyFieldsetOrderingAdmin(OrderableAdmin):
 
 class UserResponseAdmin(OrderableAdmin):
     list_display = ('fieldset', 'user_id')
-
-
-admin.site.register(models.SurveyField, SurveyFieldAdmin)
-admin.site.register(models.SurveyFieldset, SurveyFieldsetAdmin)
-admin.site.register(models.Survey, SurveyAdmin)
-admin.site.register(models.SurveyFieldOrdering, SurveyFieldOrderingAdmin)
-admin.site.register(models.SurveyFieldsetOrdering, SurveyFieldsetOrderingAdmin)
-admin.site.register(models.UserResponse, UserResponseAdmin)


### PR DESCRIPTION
Renaming `base_admin.py` to `admin.py` allows to customise the `Django` admin in the project.