### PR TITLE
Add not-empty class to field wrappers for styling

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,7 @@ This project uses Semantic Versioning (2.0).
 
 ### Upcoming
 * Add `not-empty` class to field wrapper, for styling purposes.
+* Add classes to fieldset header
 
 ### 0.3.0
 * Add surveys-form directive on-success and on-failure callbacks

--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,9 @@
 
 This project uses Semantic Versioning (2.0).
 
+### Upcoming
+* Add `not-empty` class to field wrapper, for styling purposes.
+
 ### 0.3.0
 * Add surveys-form directive on-success and on-failure callbacks
 

--- a/web/templates/twig-source/incuna-surveys/fields/fieldset-header.html
+++ b/web/templates/twig-source/incuna-surveys/fields/fieldset-header.html
@@ -1,2 +1,2 @@
-<h3 ng-bind="to.fieldGroupName"></h3>
-<h4 ng-bind="to.fieldGroupDesc"></h4>
+<h3 ng-bind="to.fieldGroupName" class="field-group-name"></h3>
+<h4 ng-bind="to.fieldGroupDesc" class="field-group-desc"></h4>

--- a/web/templates/twig-source/incuna-surveys/fields/free-text.html
+++ b/web/templates/twig-source/incuna-surveys/fields/free-text.html
@@ -1,3 +1,3 @@
-<div drf-form-field="to.fieldOptions" class="text" field-id="options.key">
+<div drf-form-field="to.fieldOptions" class="text {% raw %}{{ model[to.fieldSetId][options.key] ? 'not-empty' : '' }}{% endraw %}" field-id="{% raw %}{{ to.autoId }}{% endraw %}">
     <input type="text" class="text-input" id="{% raw %}{{ to.autoId }}{% endraw %}" ng-model="model[to.fieldSetId][options.key]" ng-required="to.fieldOptions.required">
 </div>

--- a/web/templates/twig-source/incuna-surveys/fields/free-text.html
+++ b/web/templates/twig-source/incuna-surveys/fields/free-text.html
@@ -1,3 +1,3 @@
-<div drf-form-field="to.fieldOptions" class="text {% raw %}{{ model[to.fieldSetId][options.key] ? 'not-empty' : '' }}{% endraw %}" field-id="{% raw %}{{ to.autoId }}{% endraw %}">
+<div drf-form-field="to.fieldOptions" class="text {% raw %}{{ model[to.fieldSetId][options.key] ? 'not-empty' : '' }}{% endraw %}" field-id="to.autoId">
     <input type="text" class="text-input" id="{% raw %}{{ to.autoId }}{% endraw %}" ng-model="model[to.fieldSetId][options.key]" ng-required="to.fieldOptions.required">
 </div>

--- a/web/templates/twig-source/incuna-surveys/fields/number.html
+++ b/web/templates/twig-source/incuna-surveys/fields/number.html
@@ -1,3 +1,3 @@
-<div drf-form-field="to.fieldOptions" class="number" field-id="options.key">
+<div drf-form-field="to.fieldOptions" class="number {% raw %}{{ model[to.fieldSetId][options.key] ? 'not-empty' : '' }}{% endraw %}" field-id="{% raw %}{{ to.autoId }}{% endraw %}">
     <input type="text" class="number-input" id="{% raw %}{{ to.autoId }}{% endraw %}" ng-model="model[to.fieldSetId][options.key]">
 </div>

--- a/web/templates/twig-source/incuna-surveys/fields/number.html
+++ b/web/templates/twig-source/incuna-surveys/fields/number.html
@@ -1,3 +1,3 @@
-<div drf-form-field="to.fieldOptions" class="number {% raw %}{{ model[to.fieldSetId][options.key] ? 'not-empty' : '' }}{% endraw %}" field-id="{% raw %}{{ to.autoId }}{% endraw %}">
+<div drf-form-field="to.fieldOptions" class="number {% raw %}{{ model[to.fieldSetId][options.key] ? 'not-empty' : '' }}{% endraw %}" field-id="to.autoId">
     <input type="text" class="number-input" id="{% raw %}{{ to.autoId }}{% endraw %}" ng-model="model[to.fieldSetId][options.key]">
 </div>


### PR DESCRIPTION
@incuna/js please review. We need the `not-empty` class on the wrapper of input, because input can't have pseudo element, in order to style. I think this should be in the library because it will be useful for styling across projects.

@wytrych is this what you meant about changing the field-id to match the id? 