### PR TITLE
return list of user responses

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,10 @@
 
 This project uses Semantic Versioning (2.0).
 
+### Upcoming
+
+* The response create serializer will now correctly return the instance created
+
 ### 0.13.1
 
 * Exclude test_project and web folders from distribution.

--- a/surveys/serializers.py
+++ b/surveys/serializers.py
@@ -61,19 +61,21 @@ class SurveyResponseSerializer(serializers.Serializer):
         We also need to fill in the survey, which isn't supplied explicitly for each of
         the individual user response objects.
         """
-
+        responses = list()
         survey = validated_data.pop('survey')
         user_id = validated_data.pop('user_id')
         for fieldset_pk, answers in validated_data.items():
             fieldset = survey.fieldsets.get(pk=fieldset_pk)
-            models.UserResponse.objects.create(
-                survey=survey,
-                user_id=user_id,
-                fieldset=fieldset,
-                answers=json_decode(answers),
+            responses.append(
+                models.UserResponse.objects.create(
+                    survey=survey,
+                    user_id=user_id,
+                    fieldset=fieldset,
+                    answers=json_decode(answers),
+                )
             )
 
-        return validated_data
+        return responses
 
 
 class FieldsetResponseSerializer(serializers.Serializer):

--- a/surveys/serializers.py
+++ b/surveys/serializers.py
@@ -40,6 +40,8 @@ class SurveySerializer(serializers.HyperlinkedModelSerializer):
 
 class SurveyResponseSerializer(serializers.Serializer):
     def to_representation(self, instance):
+        if isinstance(instance, dict):
+            return super(SurveyResponseSerializer, self).to_representation(instance)
         return {response.survey_id: response.answers for response in instance}
 
     def get_fields(self):

--- a/surveys/serializers.py
+++ b/surveys/serializers.py
@@ -39,6 +39,9 @@ class SurveySerializer(serializers.HyperlinkedModelSerializer):
 
 
 class SurveyResponseSerializer(serializers.Serializer):
+    def to_representation(self, instance):
+        return {response.survey_id: response.answers for response in instance}
+
     def get_fields(self):
         """
         Dynamically generate the fields from the survey fieldsets.


### PR DESCRIPTION
Create methods on DRF serilaizers should return the created instances as this allows the serializer to  store them at `serializer.instance`.

`searializer.save`
https://github.com/tomchristie/django-rest-framework/blob/master/rest_framework/serializers.py#L214

`serializer.create`
https://github.com/tomchristie/django-rest-framework/blob/master/rest_framework/serializers.py#L906

@incuna/backend 